### PR TITLE
Fix subword training

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -78,10 +78,17 @@ def train(config: DictConfig) -> nn.DataParallel:
     torch.cuda.manual_seed_all(config.train.seed)
     device = check_envirionment(config.train.use_cuda)
   
-    vocab = KsponSpeechVocabulary(
-        f'../../../data/vocab/aihub_{config.train.output_unit}_vocabs.csv',
-        output_unit=config.train.output_unit,
-    )
+    if config.train.output_unit == 'subword':
+        vocab = KsponSpeechVocabulary(
+            '../../../data/vocab/kspon_sentencepiece.vocab',
+            output_unit=config.train.output_unit,
+            sp_model_path='../../../data/vocab/kspon_sentencepiece.model',
+        )
+    else:
+        vocab = KsponSpeechVocabulary(
+            f'../../../data/vocab/aihub_{config.train.output_unit}_vocabs.csv',
+            output_unit=config.train.output_unit,
+        )
             
     if not config.train.resume:
         epoch_time_step, trainset_list, validset = split_dataset(config, config.train.transcripts_path, vocab)

--- a/dataset/kspon/preprocess/subword.py
+++ b/dataset/kspon/preprocess/subword.py
@@ -33,10 +33,11 @@ def train_sentencepiece(transcripts, datapath: str = './data', vocab_size: int =
         f'--vocab_size={vocab_size} '
         '--model_type=bpe '
         '--max_sentence_length=9999 '
-        '--hard_vocab_limit=false'
-        '--pad_id=0'
-        '--bos_id=1'
-        '--eos_id=2'
+        '--hard_vocab_limit=false '
+        '--pad_id=0 '
+        '--bos_id=1 '
+        '--eos_id=2 '
+        '--unk_id=3 '
     )
 
 

--- a/kospeech/vocabs/ksponspeech.py
+++ b/kospeech/vocabs/ksponspeech.py
@@ -19,6 +19,9 @@ from kospeech.vocabs import Vocabulary
 class KsponSpeechVocabulary(Vocabulary):
     def __init__(self, vocab_path, output_unit: str = 'character', sp_model_path=None):
         super(KsponSpeechVocabulary, self).__init__()
+        self.vocab_path = vocab_path
+        self.output_unit = output_unit
+
         if output_unit == 'subword':
             import sentencepiece as spm
             self.sp = spm.SentencePieceProcessor()
@@ -27,16 +30,13 @@ class KsponSpeechVocabulary(Vocabulary):
             self.pad_id = 0
             self.sos_id = 1
             self.eos_id = 2
-            self.blank_id = len(self)
+            self.blank_id = 3
         else:
             self.vocab_dict, self.id_dict = self.load_vocab(vocab_path, encoding='utf-8')
             self.sos_id = int(self.vocab_dict['<sos>'])
             self.eos_id = int(self.vocab_dict['<eos>'])
             self.pad_id = int(self.vocab_dict['<pad>'])
             self.blank_id = int(self.vocab_dict['<blank>'])
-
-        self.vocab_path = vocab_path
-        self.output_unit = output_unit
 
     def __len__(self):
         if self.output_unit == 'subword':


### PR DESCRIPTION
OUTPUT_UNIT이 Subword일 때, kson 전처리 단계와 모델 학습시 에러가 발생하는 부분을 수정하였습니다.

sentencepiece의 경우 unk-id가 생략된 경우, 에러가 발생하여 unk-id를 추가하였습니다.

subword에서는 blank-id를 사용하지 않기 때문에, 이 부분을 unk-id와 동일하게 처리하였는데, 이 부분은 검토가 필요합니다.